### PR TITLE
Add RedSage bibliography entry and CVPR 2026 acceptance announcement

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -3,6 +3,19 @@
 
 @string{aps = {American Physical Society,}}
 
+@inproceedings{
+suryanto2026redsage,
+title={RedSage: A Cybersecurity Generalist {LLM}},
+author={Naufal Suryanto and Muzammal Naseer and Pengfei Li and Syed Talal Wasim and Jinhui Yi and Juergen Gall and Paolo Ceravolo and Ernesto Damiani},
+booktitle={The Fourteenth International Conference on Learning Representations},
+year={2026},
+url={https://openreview.net/forum?id=W4FAenIrQ2},
+html = {https://openreview.net/forum?id=W4FAenIrQ2},
+website = {https://risys-lab.github.io/RedSage/},
+pdf = {https://openreview.net/pdf?id=W4FAenIrQ2},
+bibtex_show = {true}
+}
+
 @Article{Suryanto_2025_IEEACCESS,
   author={Suryanto, Naufal and Adiputra, Andro Aprila and Kadiptya, Ahmada Yusril and Le, Thi-Thu-Huong and Pratama, Derry and Kim, Yongsu and Kim, Howon},
   journal={IEEE Access}, 

--- a/_news/announcement_7.md
+++ b/_news/announcement_7.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-02-21 09:00:00+0400
+inline: true
+related_posts: false
+---
+
+Our paper has been accepted to CVPR 2026! 🎉


### PR DESCRIPTION
### Motivation
- Add a new bibliographic record for the RedSage paper and publish a short site announcement to reflect a paper acceptance for CVPR 2026.

### Description
- Add `@inproceedings` entry `suryanto2026redsage` to `_bibliography/papers.bib` including `title`, `author`, `booktitle`, `year`, `url`, `html`, `website`, `pdf`, and `bibtex_show` fields.
- Add new news post `_news/announcement_7.md` with front matter metadata and a brief message announcing the CVPR 2026 acceptance.

### Testing
- No automated tests were run for these content changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8787addc0832591595524e09f7b0b)